### PR TITLE
Port mapping for payment-camunda did not work

### DIFF
--- a/runner/docker-compose/docker-compose-kafka-java-order-camunda.yml
+++ b/runner/docker-compose/docker-compose-kafka-java-order-camunda.yml
@@ -56,7 +56,7 @@ services:
     networks:
       - flowing
     ports:
-      - "8093:8094"
+      - "8093:8093"
     depends_on:
       - kafka
     environment:


### PR DESCRIPTION
Service internally seems to run on port 8093, not 8094 (according to source code)